### PR TITLE
转16进制后,签名不通过

### DIFF
--- a/src/Gateways/CMBank/CMBaseObject.php
+++ b/src/Gateways/CMBank/CMBaseObject.php
@@ -90,8 +90,8 @@ abstract class CMBaseObject extends BaseObject
                 case 'SHA-256':
                     $signStr .= '&' . $this->merKey;
                     $signStr = StrUtil::characet($signStr, 'UTF-8');
-                    $sign    = bin2hex(hash('sha256', $signStr));
-                    //$sign = hash('sha256', $signStr);
+                    //$sign    = bin2hex(hash('sha256', $signStr));
+                    $sign = hash('sha256', $signStr);
                     break;
                 default:
                     throw new GatewayException(sprintf('[%s] sign type not support', $this->signType), Payment::PARAMS_ERR);


### PR DESCRIPTION
招行这块的文档说需要转16进制,但是PHP的demo中,这里显示"可选",但是实际上,如果不转,就能验证通过,转了就不通过